### PR TITLE
[10.0] [FIX] password no login nl66278

### DIFF
--- a/password_security/models/res_company.py
+++ b/password_security/models/res_company.py
@@ -49,3 +49,8 @@ class ResCompany(models.Model):
         default=24,
         help='Amount of hours until a user may change password again',
     )
+    password_no_login = fields.Boolean(
+        'Password cannot contain Login',
+        default=True,
+        help='Disallow passwords containing the login.',
+    )

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -56,6 +56,8 @@ class ResUsers(models.Model):
             message.append('\n* ' + _('Numeric digit'))
         if company_id.password_special:
             message.append('\n* ' + _('Special character'))
+        if company_id.password_no_login:
+            message.append('\n* ' + _('Must not contain Login'))
         if message:
             message = [_('Must contain the following:')] + message
         if company_id.password_length:
@@ -88,6 +90,8 @@ class ResUsers(models.Model):
             password_regex.append(r'(?=.*?[\W_])')
         password_regex.append('.{%d,}$' % company_id.password_length)
         if not re.search(''.join(password_regex), password):
+            raise PassError(self.password_match_message())
+        if company_id.password_no_login and self.login in password:
             raise PassError(self.password_match_message())
         return True
 

--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -91,8 +91,9 @@ class ResUsers(models.Model):
         password_regex.append('.{%d,}$' % company_id.password_length)
         if not re.search(''.join(password_regex), password):
             raise PassError(self.password_match_message())
-        if company_id.password_no_login and self.login in password:
-            raise PassError(self.password_match_message())
+        if company_id.password_no_login:
+            if self.login.lower() in password.lower():
+                raise PassError(self.password_match_message())
         return True
 
     @api.multi

--- a/password_security/tests/test_res_users.py
+++ b/password_security/tests/test_res_users.py
@@ -168,6 +168,6 @@ class TestResUsers(TransactionCase):
     def test_password_contains_login(self):
         self.assertTrue(self.main_comp.password_no_login)
         rec_id = self._new_record()
-        rec_id._check_password('asdQWE123$%^12')
+        rec_id.login = 'suzanne'
         with self.assertRaises(PassError):
-            rec_id._check_password(rec_id.login + 'invalid')
+            rec_id._check_password('Suzanne1966!')

--- a/password_security/tests/test_res_users.py
+++ b/password_security/tests/test_res_users.py
@@ -164,3 +164,10 @@ class TestResUsers(TransactionCase):
         self.assertTrue(self.main_comp.password_special)
         rec_id = self._new_record()
         rec_id._check_password('asdQWE12345_3')
+
+    def test_password_contains_login(self):
+        self.assertTrue(self.main_comp.password_no_login)
+        rec_id = self._new_record()
+        rec_id._check_password('asdQWE123$%^12')
+        with self.assertRaises(PassError):
+            rec_id._check_password(rec_id.login + 'invalid')

--- a/password_security/views/res_company_view.xml
+++ b/password_security/views/res_company_view.xml
@@ -22,6 +22,7 @@
                         <group string="Extra">
                             <field name="password_length" />
                             <field name="password_history" />
+                            <field name="password_no_login" />
                         </group>
                     </group>
                     <group name="chars_grp" string="Required Characters">


### PR DESCRIPTION
Test succeeded only because exception was raised due to all lowercase password. Not because login was in password, that check was never done.

Also method failed to check for login in password with differing case.