### PR TITLE
[FIX] [10.0]  Correct test for password not in login.

### DIFF
--- a/password_security/models/res_users.py
+++ b/password_security/models/res_users.py
@@ -91,8 +91,9 @@ class ResUsers(models.Model):
         password_regex.append('.{%d,}$' % company_id.password_length)
         if not re.search(''.join(password_regex), password):
             raise PassError(self.password_match_message())
-        if company_id.password_no_login and self.login in password:
-            raise PassError(self.password_match_message())
+        if company_id.password_no_login:
+            if self.login.lower() in password.lower():
+                raise PassError(self.password_match_message())
         return True
 
     @api.multi

--- a/password_security/tests/test_res_users.py
+++ b/password_security/tests/test_res_users.py
@@ -168,6 +168,6 @@ class TestResUsers(TransactionCase):
     def test_password_contains_login(self):
         self.assertTrue(self.main_comp.password_no_login)
         rec_id = self._new_record()
-        rec_id._check_password('asdQWE123$%^12')
+        rec_id.login = 'suzanne'
         with self.assertRaises(PassError):
-            rec_id._check_password(rec_id.login + 'invalid')
+            rec_id._check_password('Suzanne1966!')


### PR DESCRIPTION
Test succeeded only because exception was raised due to all lowercase password. Not because login was in password, that check was never done.

Also method failed to check for login in password with differing case.